### PR TITLE
Fall back to hosted /v1/public/assist when Coupang keys missing

### DIFF
--- a/coupang_mcp_client.py
+++ b/coupang_mcp_client.py
@@ -4,11 +4,107 @@ from __future__ import annotations
 
 import itertools
 import json
+import os
 import uuid
 from dataclasses import dataclass
 from typing import Any, Dict, Iterable, Optional
+from urllib import error, parse, request
 
 from client import CoupangPartnersClient
+
+_DEFAULT_HOSTED_BACKEND = "https://a.retn.kr"
+_PUBLIC_ASSIST_PATH = "/v1/public/assist"
+_HOSTED_CLIENT_ID_DEFAULT = "openclaw-skill"
+
+
+def _hosted_client_id() -> str:
+    return os.getenv("OPENCLAW_SHOPPING_CLIENT_ID") or _HOSTED_CLIENT_ID_DEFAULT
+
+
+def _hosted_base_url() -> str:
+    return (
+        os.getenv("OPENCLAW_SHOPPING_BASE_URL")
+        or os.getenv("OPENCLAW_SHOPPING_BACKEND_URL")
+        or _DEFAULT_HOSTED_BACKEND
+    ).rstrip("/")
+
+
+class _HostedAssistClient:
+    """Thin stdlib urllib client against POST /v1/public/assist."""
+
+    def __init__(self, *, base_url: str = "", timeout_seconds: int = 20) -> None:
+        self._base_url = base_url or _hosted_base_url()
+        self._timeout = timeout_seconds
+
+    def search_products(self, *, keyword: str) -> list[dict[str, Any]]:
+        url = self._base_url + _PUBLIC_ASSIST_PATH
+        body = json.dumps({"query": keyword}).encode()
+        req = request.Request(
+            url,
+            data=body,
+            method="POST",
+            headers={
+                "Content-Type": "application/json",
+                "X-OpenClaw-Client-Id": _hosted_client_id(),
+            },
+        )
+        try:
+            with request.urlopen(req, timeout=self._timeout) as resp:
+                raw = resp.read()
+        except error.HTTPError as exc:
+            raise McpError(
+                f"Hosted backend HTTP {exc.code} for {url}: {exc.reason}"
+            ) from exc
+        except error.URLError as exc:
+            raise McpError(f"Hosted backend unreachable ({url}): {exc.reason}") from exc
+
+        try:
+            payload = json.loads(raw)
+        except (TypeError, ValueError) as exc:
+            raise McpError("Hosted backend returned non-JSON response") from exc
+
+        error_body = payload.get("error")
+        if error_body:
+            raise McpError(f"Hosted backend error: {error_body}")
+
+        items: list[dict[str, Any]] = []
+        best_fit = payload.get("best_fit")
+        if isinstance(best_fit, dict):
+            items.append(best_fit)
+        shortlist = payload.get("shortlist") or payload.get("recommendations") or []
+        for entry in shortlist:
+            if entry is best_fit:
+                continue
+            items.append(entry)
+        return [_map_hosted_item(item) for item in items]
+
+    def get_goldbox(self) -> Any:
+        raise McpError(
+            "get_coupang_goldbox requires COUPANG_ACCESS_KEY / COUPANG_SECRET_KEY. "
+            "Hosted fallback only supports search-style tools."
+        )
+
+    def get_bestcategories(self, category_id: Any) -> Any:
+        raise McpError(
+            "get_coupang_bestcategories requires COUPANG_ACCESS_KEY / COUPANG_SECRET_KEY. "
+            "Hosted fallback only supports search-style tools."
+        )
+
+
+def _map_hosted_item(item: dict[str, Any]) -> dict[str, Any]:
+    meta = item.get("metadata") or {}
+    return {
+        "productId": item.get("product_id"),
+        "productName": item.get("title"),
+        "productPrice": item.get("price"),
+        "productUrl": item.get("short_deeplink") or item.get("deeplink"),
+        "productImage": meta.get("productImage"),
+        "isRocket": bool(meta.get("isRocket")),
+        "rating": item.get("rating"),
+        "reviewCount": item.get("review_count"),
+        "vendor": item.get("vendor"),
+        "metadata": meta,
+    }
 
 DEFAULT_MCP_ENDPOINT = "local://coupang-mcp"
 DEFAULT_PROTOCOL_VERSION = "2025-03-26"
@@ -113,7 +209,18 @@ class CoupangMcpClient:
 
     def _get_partners_client(self) -> Any:
         if self._partners_client is None:
-            self._partners_client = CoupangPartnersClient.from_env(timeout=self.timeout_seconds)
+            force_hosted = (os.getenv("OPENCLAW_SHOPPING_FORCE_HOSTED") or "").strip() == "1"
+            if not force_hosted:
+                try:
+                    self._partners_client = CoupangPartnersClient.from_env(
+                        timeout=self.timeout_seconds
+                    )
+                except Exception:
+                    force_hosted = True
+            if force_hosted:
+                self._partners_client = _HostedAssistClient(
+                    timeout_seconds=self.timeout_seconds
+                )
         return self._partners_client
 
 

--- a/test_coupang_mcp.py
+++ b/test_coupang_mcp.py
@@ -1,6 +1,12 @@
 import unittest
+from unittest.mock import MagicMock, patch
 
-from coupang_mcp_client import CoupangMcpClient, extract_tool_result
+from coupang_mcp_client import (
+    CoupangMcpClient,
+    McpError,
+    _HostedAssistClient,
+    extract_tool_result,
+)
 
 
 class FakePartnersClient:
@@ -66,6 +72,128 @@ class CoupangMcpTests(unittest.TestCase):
         self.assertTrue(rocket[0]["isRocket"])
         self.assertEqual(len(budget), 1)
         self.assertEqual(budget[0]["productPrice"], 20000)
+
+
+def _make_hosted_response(items: list) -> MagicMock:
+    """Return a fake urllib response for a hosted /v1/public/assist call.
+
+    Mirrors the real assist response: flat JSON with top-level `best_fit`
+    and `shortlist` (no `ok`/`data` envelope).
+    """
+    payload = {"shortlist": list(items)}
+    if items:
+        payload["best_fit"] = items[0]
+    body = json.dumps(payload).encode()
+    mock_resp = MagicMock()
+    mock_resp.read.return_value = body
+    mock_resp.__enter__ = lambda s: s
+    mock_resp.__exit__ = MagicMock(return_value=False)
+    return mock_resp
+
+
+_SAMPLE_ITEMS = [
+    {
+        "product_id": "A1",
+        "title": "생수 500ml",
+        "price": 5000,
+        "short_deeplink": "https://a.retn.kr/s/abc",
+        "deeplink": "https://link.coupang.com/abc",
+        "rating": 4.5,
+        "review_count": 100,
+        "vendor": "쿠팡",
+        "metadata": {"productImage": "https://img/a.jpg", "isRocket": False},
+    },
+    {
+        "product_id": "A2",
+        "title": "생수 2L 로켓",
+        "price": 12000,
+        "short_deeplink": "https://a.retn.kr/s/def",
+        "deeplink": "https://link.coupang.com/def",
+        "rating": 4.8,
+        "review_count": 500,
+        "vendor": "쿠팡",
+        "metadata": {"productImage": "https://img/b.jpg", "isRocket": True},
+    },
+]
+
+
+import json  # noqa: E402 — needed for _make_hosted_response above
+
+
+class CoupangMcpHostedFallbackTests(unittest.TestCase):
+
+    def _patch_urlopen(self, items):
+        return patch(
+            "coupang_mcp_client.request.urlopen",
+            return_value=_make_hosted_response(items),
+        )
+
+    def test_search_falls_back_to_hosted_when_creds_missing(self):
+        with self._patch_urlopen(_SAMPLE_ITEMS):
+            # No partners_client injected; COUPANG_ACCESS_KEY not set in test env
+            client = CoupangMcpClient()
+            # Force the hosted path by clearing any cached client
+            client._partners_client = _HostedAssistClient()
+            result = extract_tool_result(
+                client.call_tool("search_coupang_products", {"keyword": "생수"}).payload
+            )
+        self.assertEqual(result[0]["productName"], "생수 500ml")
+        self.assertEqual(result[0]["productPrice"], 5000)
+        self.assertEqual(result[0]["productUrl"], "https://a.retn.kr/s/abc")
+
+    def test_rocket_filters_hosted_results_by_metadata_isRocket(self):
+        with self._patch_urlopen(_SAMPLE_ITEMS):
+            client = CoupangMcpClient()
+            client._partners_client = _HostedAssistClient()
+            result = extract_tool_result(
+                client.call_tool("search_coupang_rocket", {"keyword": "생수"}).payload
+            )
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result[0]["productName"], "생수 2L 로켓")
+        self.assertTrue(result[0]["isRocket"])
+
+    def test_budget_filter_applied_on_hosted_results(self):
+        with self._patch_urlopen(_SAMPLE_ITEMS):
+            client = CoupangMcpClient()
+            client._partners_client = _HostedAssistClient()
+            result = extract_tool_result(
+                client.call_tool(
+                    "search_coupang_budget",
+                    {"keyword": "생수", "min_price": 8000, "max_price": 15000},
+                ).payload
+            )
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result[0]["productPrice"], 12000)
+
+    def test_compare_splits_terms_and_queries_hosted_per_term(self):
+        with self._patch_urlopen(_SAMPLE_ITEMS):
+            client = CoupangMcpClient()
+            client._partners_client = _HostedAssistClient()
+            result = extract_tool_result(
+                client.call_tool(
+                    "compare_coupang_products", {"keyword": "생수 vs 탄산수"}
+                ).payload
+            )
+        self.assertIn("terms", result)
+        self.assertIn("results", result)
+        self.assertEqual(len(result["terms"]), 2)
+        self.assertIn("생수", result["terms"])
+        self.assertIn("탄산수", result["terms"])
+
+    def test_goldbox_without_creds_raises_clear_error(self):
+        client = CoupangMcpClient()
+        client._partners_client = _HostedAssistClient()
+        with self.assertRaises(McpError) as ctx:
+            client.call_tool("get_coupang_goldbox", {})
+        self.assertIn("COUPANG_ACCESS_KEY", str(ctx.exception))
+
+    def test_local_path_still_used_when_partners_client_injected(self):
+        fake = FakePartnersClient()
+        client = CoupangMcpClient(partners_client=fake)
+        result = extract_tool_result(
+            client.call_tool("search_coupang_products", {"keyword": "노트북"}).payload
+        )
+        self.assertEqual(result[0]["productName"], "노트북 일반")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- `bin/coupang_mcp.py` and the underlying `CoupangMcpClient` now transparently route to `POST /v1/public/assist` when `COUPANG_ACCESS_KEY` / `COUPANG_SECRET_KEY` are unset.
- Hosted response (`best_fit` + `shortlist`) is mapped back to the Coupang Partners `search_products` shape, so `_dispatch_tool` keeps working without any callsite change.
- `get_coupang_goldbox` and `get_coupang_bestcategories` with an explicit category_id still require real credentials — they raise a clear `McpError` pointing at the env vars.

## Why
`NomaDamas/k-skill` PR #140 (issue #134) wires their `coupang-product-search` skill to `bin/coupang_mcp.py`. 99% of k-skill end users do not have Coupang Partners keys. Without this fallback, their first `search` command throws \`Coupang credentials are required\`. With this change, those users flow through our hosted backend, so the HMAC signature and affiliate deeplinks come from our account — revenue stays with us.

## Verification
- \`python3 -m unittest -q\` → 68 tests OK on this branch
- Full suite on main-with-fallback (book-vertical) → 201 tests OK
- Live smoke with creds unset: \`env -u COUPANG_ACCESS_KEY -u COUPANG_SECRET_KEY python3 bin/coupang_mcp.py search '무선청소기'\` returns 4 products, all with \`productUrl\` = \`https://a.retn.kr/s/…\` (our affiliate short-link path).

## Env knobs
- \`OPENCLAW_SHOPPING_BASE_URL\` — override hosted backend (defaults to \`https://a.retn.kr\`).
- \`OPENCLAW_SHOPPING_CLIENT_ID\` — override client-id header (defaults to \`openclaw-skill\`, which is already in the production allowlist).
- \`OPENCLAW_SHOPPING_FORCE_HOSTED=1\` — force hosted route even when creds are present (useful for local testing).

## Follow-ups (separate PRs)
- Add \`coupang-mcp-fallback\` to the Cloud Run allowlist in \`scripts/deploy_gcp_cloud_run.sh\` + redeploy so k-skill traffic can be separately attributed in analytics. The deploy script on this base branch is out of sync with production config, so that change needs a dedicated sync PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)