### PR TITLE
Degrade assist to empty shortlist on CoupangApiError instead of 500

### DIFF
--- a/backend.py
+++ b/backend.py
@@ -6,7 +6,7 @@ from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from typing import Any, Dict, List, Optional
 
 from analytics import AnalyticsStore, build_analytics_store_from_env
-from client import CoupangPartnersClient
+from client import CoupangApiError, CoupangPartnersClient
 from economics import build_economics_summary
 from recommendation import (
     build_assist_response,
@@ -76,10 +76,21 @@ class ShoppingBackend:
             raise BackendError(HTTPStatus.BAD_REQUEST, "'query' is required")
         evidence_snippets = _normalize_evidence_snippets(payload.get("evidence_snippets") or [])
         search_plan = build_search_queries(normalized)
-        products = self._search_products(
-            query=query,
-            search_plan=search_plan,
-        )
+        degraded_reason: Optional[str] = None
+        try:
+            products = self._search_products(
+                query=query,
+                search_plan=search_plan,
+            )
+        except CoupangApiError as exc:
+            products = []
+            degraded_reason = f"coupang_api_status_{exc.status_code}"
+            log_event(
+                "coupang_search_degraded",
+                query=query,
+                status_code=exc.status_code,
+                reason=str(exc)[:200],
+            )
         recommendations = recommend_products(
             query=query,
             products=_filter_products(
@@ -106,12 +117,15 @@ class ShoppingBackend:
             )
         except Exception as exc:
             log_event("analytics_error", stage="record_assist", query=query, error=str(exc))
-        return build_assist_response(
+        response = build_assist_response(
             normalized=normalized,
             search_plan=search_plan,
             recommendations=recommendations,
             query_id=query_id,
         )
+        if degraded_reason:
+            response["degraded"] = degraded_reason
+        return response
 
     def deeplinks(self, payload: Dict[str, Any]) -> Dict[str, Any]:
         urls = payload.get("urls") or payload.get("coupangUrls") or []

--- a/test_backend.py
+++ b/test_backend.py
@@ -388,6 +388,22 @@ class BackendTests(unittest.TestCase):
         response = backend.assist({"query": "30만원 이하 무선청소기"})
         self.assertEqual(response["best_fit"]["short_deeplink"], "https://www.coupang.com/vp/products/1")
 
+    def test_assist_degrades_gracefully_on_coupang_api_error(self):
+        from client import CoupangApiError
+
+        class FailingAdapter:
+            def search_products(self, **params):
+                raise CoupangApiError(429, {"rCode": "ERROR", "rMessage": "rate limited"})
+
+        backend = ShoppingBackend(
+            adapter=FailingAdapter(),
+            analytics_store=AnalyticsStore(f"{self.tempdir.name}/degraded.sqlite3"),
+        )
+        response = backend.assist({"query": "30만원 이하 무선청소기"})
+        self.assertEqual(response["shortlist"], [])
+        self.assertIsNone(response["best_fit"])
+        self.assertEqual(response["degraded"], "coupang_api_status_429")
+
     def test_assist_does_not_shorten_invalid_recommendation_targets(self):
         class InvalidUrlAdapter(FakeAdapter):
             def search_products(self, **params):


### PR DESCRIPTION
## Why

An adversarial reliability audit on 2026-04-21 surfaced that the assist handler's call to `_search_products` had no `CoupangApiError` catch, so any upstream Coupang 429 / 5xx / 403 turned into a plain HTTP 500. This contradicts the \`CLAUDE.md\` promise of graceful degradation and breaks the \"always returns a well-formed shortlist\" contract that keyless k-skill users now rely on via PR #1's hosted fallback path.

This is the top-priority follow-up from the audit (\"highest leverage — the thing a careful downstream maintainer will catch first\").

## Change

- Catch \`CoupangApiError\` around the \`_search_products\` call in \`backend.py\`.
- Substitute an empty products list; the rest of the pipeline (filter, rank, evidence, shortener, analytics) still runs.
- Emit a \`coupang_search_degraded\` analytics event with the upstream status code so we can observe the flap.
- Response shape is unchanged on success. On degradation the response gains an optional top-level field \`\"degraded\": \"coupang_api_status_<code>\"\` (e.g. \`coupang_api_status_429\`); callers that don't know about it can ignore it.

## Verification

- \`python3 -m unittest -q\` → 69 tests OK.
- New \`test_assist_degrades_gracefully_on_coupang_api_error\` covers a 429 path end-to-end and asserts empty \`shortlist\`, \`best_fit is None\`, and \`degraded == \"coupang_api_status_429\"\`.

## Follow-ups (separate PRs)

- Landing-page enrichment is currently serial; concurrent fan-out with a hard wall-budget is the next biggest latency win.
- In-process rate limiter leaks 3× amplification under \`max-instances=3\`; move to Firestore-backed bucket or pin concurrency.

🤖 Generated with [Claude Code](https://claude.com/claude-code)